### PR TITLE
Docs: Update raw query section to reflect changes from 0.6.0

### DIFF
--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -88,6 +88,12 @@ const profile = await cirql.execute({
 
 When adding or subtracting items from arrays, you can use the `add` and `remove` functions instead of eq for inserting `+=` and `-=` operators.
 
+### Available raw functions
+We currently provide access to following raw functions:
+- [type](https://surrealdb.com/docs/surrealql/functions/type)
+- [time](https://surrealdb.com/docs/surrealql/functions/time)
+- [rand](https://surrealdb.com/docs/surrealql/functions/rand)
+
 ## Batched queries & transactions
 While you can use `.execute()` to send a single query to SurrealDB, you can also use `.batch()` and `.transaction()` to send multiple queries in a single request.
 

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -90,9 +90,9 @@ When adding or subtracting items from arrays, you can use the `add` and `remove`
 
 ### Available raw functions
 We currently provide access to following raw functions:
-- [type](https://surrealdb.com/docs/surrealql/functions/type)
-- [time](https://surrealdb.com/docs/surrealql/functions/time)
 - [rand](https://surrealdb.com/docs/surrealql/functions/rand)
+- [time](https://surrealdb.com/docs/surrealql/functions/time)
+- [type](https://surrealdb.com/docs/surrealql/functions/type)
 
 ## Batched queries & transactions
 While you can use `.execute()` to send a single query to SurrealDB, you can also use `.batch()` and `.transaction()` to send multiple queries in a single request.

--- a/docs/guide/basic-usage.md
+++ b/docs/guide/basic-usage.md
@@ -71,11 +71,13 @@ While the Query Writer API provides a safe way to write queries, it is still pos
 In the following example we are creating a new organisation, and setting the `createdAt` field to the current time using the Surreal `time::now()` function.
 
 ```ts
+import { time } from 'cirql'
+
 const profile = await cirql.execute({ 
     query: create('organisation').setAll({
         name: 'Example',
         isEnabled: eq('$enable'),
-        createdAt: eq(timeNow()) // time::now()
+        createdAt: eq(time.now()) // time::now()
     }),
     schema: Organisation,
     params: {


### PR DESCRIPTION
Per the changelog of 0.6.0: Removed deprecated timeNow() function, you should instead use time.now() I am updating docs to reflect this, also added links for the available raw functions to the SurrealDB docs. 