### PR TITLE
Feat: update guide to match version 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ This repository follows the same [Contributor Guide](https://github.com/Starlane
 ### Requirements
 - [PNPM](https://pnpm.io/) (npm i -g pnpm)
 
-Copyright (c) 2023, Starlane Studios
+Copyright (c) 2024, Starlane Studios

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -13,12 +13,40 @@ You can of course use any package manager (npm, yarn, pnpm, etc).
 
 ## Connecting to SurrealDB
 
-You can connect to SurrealDB in a statefull or stateless way. For this tutorial we will be using the statefull API using WebSockets under the hood.
+You can connect to SurrealDB in 3 ways:
+- statefull way using WebSockets from surrealdb.js API (new from v1.0.0); 
+- statefull way using WebSockets (legacy v0.7.9);
+- stateless way using HTTP requests (legacy v0.7.9). 
+
+### Statefull request
+
+By default, since v1.0.0, Cirql uses [surrealdb.js API](https://docs.surrealdb.com/docs/integration/sdks/nodejs/) to connect to SurrealDB instance. This ensures compatibility with existing official SDK and allow to add Cirql functionality on top of it. 
+Here is an example how to connect to database:
 
 ```ts
 import { Cirql } from 'cirql';
 
-const cirql = new Cirql({
+const cirql = new Cirql();
+
+await cirql.handle.connect('http://localhost:8000/');
+await cirql.handle.signin({
+    namespace: 'test',
+    database: 'test',
+    username: 'root',
+    password: 'root',
+});
+```
+
+This will automatically make Cirql open a connection to SurrealDB.
+
+### Legacy statefull request
+
+Here is an example how to connect to database using v0.7.9 API:
+
+```ts
+import { LegacyCirqlStateful } from 'cirql';
+
+const cirql = new LegacyCirqlStateful({
     connection: {
         endpoint: 'http://localhost:8000/',
         namespace: 'test',
@@ -33,7 +61,7 @@ const cirql = new Cirql({
 
 This will automatically make Cirql open a connection to SurrealDB. If you prefer to handle this manually, you may configure `autoConnect` to `false`.
 
-### Waiting for the connection
+#### Waiting for the connection
 
 You can wait for the connection to open by using the ready function. From this point on you will be able to send queries to the database.
 ```ts
@@ -42,7 +70,7 @@ await cirql.ready();
 
 Alternatively, you can also listen to the `open` event using `addEventListener`.
 
-### Manual connection management
+#### Manual connection management
 
 If you have to disabled auto connect, you can manually initiate the connection using the connect function.
 ```ts

--- a/docs/guide/stateless.md
+++ b/docs/guide/stateless.md
@@ -9,9 +9,9 @@ By default Cirql will connect to SurrealDB using stateful WebSockets. This allow
 Cirql provides an alternative API for sending queries in seperate HTTP requests. This is especially useful for situations like Server Side Rendering where credentials may differ per request.
 
 ```ts
-import { CirqlStateless, select } from 'cirql';
+import { LegacyCirqlStateless, select } from 'cirql';
 
-const cirql = new CirqlStateless({
+const cirql = new LegacyCirqlStateless({
     connection: {
         endpoint: 'http://localhost:8000/',
         namespace: 'test',


### PR DESCRIPTION
As this documentation resembles version 0.7.9, I felt it would be good and less confusing for newcomers (like me) to bump the "Guide" section that would use current classes' names and at least provide an example of new "surrealdb.js"-based way of connection.