### PR TITLE
Feat: fill API reference pages

### DIFF
--- a/docs/api/count.md
+++ b/docs/api/count.md
@@ -3,3 +3,29 @@ sidebar_position: 8
 ---
 
 # Counting rows
+Count query writer is used to count the rows of the table.
+
+Under the hood it performs `SELECT` query with SurrealQL [`count`](https://docs.surrealdb.com/docs/surrealql/functions/count/) function. It may be useful to build subquery in `SELECT` main query with `GROUP BY/GROUP ALL` clause. 
+
+## `count(target: SurrealValue)`
+Starts a new count query writer with the given target.
+
+## `countRecord(record: string)`
+Starts a new count query writer for the given record.
+
+Unlike the `count` function this function will ensure that the record is a valid record link, which may be beneficial in situations where potential injection attacks are a concern.
+
+## `countRecord(table: string, id: string)`
+Starts a new count query writer for the given record. This function is especially useful in situations where the table name within a record pointer may be spoofed, and a specific table name is required.
+
+## `countRelation(relation: RecordRelation)`
+Starts a new count query writer for the given relation. This function is especially useful in situations where the table names within a record pointer may be spoofed, and specific table names are required.
+
+Since this function will automatically configure a `WHERE` clause, calling `.where()` manually will throw an exception.
+
+## Methods
+
+### `WHERE` clause
+
+#### `.where(where: string | Where)`
+Defines a predicate function that determines whether a specific query will be counted or not. All values will be escaped automatically. Use of `raw` is supported, as well as any operators wrapping the raw function.

--- a/docs/api/create.md
+++ b/docs/api/create.md
@@ -3,3 +3,77 @@ sidebar_position: 2
 ---
 
 # Create
+Create query writer resembles `CREATE` SQL statement. It is used to create various entities in SurrealDB database.
+
+For additional information about that statement in SurrealQL you can refer to [official docs](https://docs.surrealdb.com/docs/surrealql/statements/create/).
+
+## `create(...targets: SurrealValue[])`
+Starts a new create query writer with the given targets.
+
+## `createRecord(record: string)`
+Starts a new create query writer for the given record.
+
+Unlike the `create` function this function will ensure that the record is a valid record link, which may be beneficial in situations where potential injection attacks are a concern.
+
+## `createRecord(table: string, id: string)`
+Starts a new create query writer for the given record. This function is especially useful in situations where the table name within a record pointer may be spoofed, and a specific table name is required.
+
+## Methods
+Cirql provides methods of 2 types:
+- Cirql-native above SurrealQL (described in 'sections');
+- SurrealQL-native resembling SurrealQL clauses (described in respective 'clauses').
+
+### `WITH` section
+
+#### `.with<NS extends ZodTypeAny>(schema: NS)`
+Defines the Zod schema that should be used to validate the query result.
+
+#### `.withSchema<T extends ZodRawShape>(schema: T)`
+Defines the schema that should be used to validate the query result, useful in situations where you need to validate the query result against the schema without creating one beforehand.
+
+This is short for `with(z.object(schema))`.
+
+#### `.withAny()`
+Defines a schema which accepts any value, useful in situations where a specific schema isn't needed.
+
+This is short for `with(z.any())`.
+
+### `SET/CONTENT` clause
+
+#### `.set(key: SchemaFields, value: any)`
+Sets an individual field to a value.
+
+#### `.setAll(fields: SchemaInput)`
+Sets multiple fields at once using an object. Supports recursive objects and raw values. Can be used as effective alternative to `content`.
+
+#### `.content(content: SchemaInput)`
+Sets the content for the created record.
+
+The content is serialized to JSON, meaning you can not use raw query values. Thus, when raw values are needed, use the `setAll` function instead.
+
+### `RETURN` clause
+
+#### `.return(mode: 'none' | 'before' | 'after' | 'diff')`
+Defines the return behavior mode `mode` for the query.
+
+Mode can be either one of these:
+- `'none'` - Doesn't return any result;
+- `'diff'` - Returns the changeset diff;
+- `'before'` - Returns the record before changes were applied;
+- `'after'` - Returns the record after changes were applied.
+
+If no value is set throughout query writer configuring, the default one is `'after'`.
+
+#### `.return(...fields: SchemaFields[])`
+Defines the return behavior mode for the query as returning specified fields.
+
+### `TIMEOUT` clause
+
+#### `.timeout(timeout: number)`
+Sets the timeout in seconds for the query.
+
+### `PARALLEL` clause
+
+#### `.parallel()`
+Runs the query in parallel.
+

--- a/docs/api/delete.md
+++ b/docs/api/delete.md
@@ -3,3 +3,78 @@ sidebar_position: 4
 ---
 
 # Delete
+Delete query writer resembles `DELETE` SQL statement. It is used to delete various entities in SurrealDB database.
+
+For additional information about that statement in SurrealQL you can refer to [official docs](https://docs.surrealdb.com/docs/surrealql/statements/delete/).
+
+> Note: do not confuse it with other similar statement - `REMOVE`.
+
+## `del(...targets: SurrealValue[])`
+Starts a new delete query writer with the given targets.
+
+> Note: as 'delete' is already a JavaScript [keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete/), all Cirql functions that construct delete query writer have 'del' prefix.
+
+## `delRecord(record: string)`
+Starts a new delete query writer for the given record.
+
+Unlike the `del` function this function will ensure that the record is a valid record link, which may be beneficial in situations where potential injection attacks are a concern.
+
+## `delRecord(table: string, id: string)`
+Starts a new delete query writer for the given record. This function is especially useful in situations where the table name within a record pointer may be spoofed, and a specific table name is required.
+
+## `delRelation(relation: RecordRelation)`
+Starts a new delete query writer for the given relation. This function is especially useful in situations where the table names within a record pointer may be spoofed, and specific table names are required.
+
+Since this function will automatically configure a `WHERE` clause, calling `.where()` manually will throw an exception.
+
+## Methods
+Cirql provides methods of 2 types:
+- Cirql-native above SurrealQL (described in 'sections');
+- SurrealQL-native resembling SurrealQL clauses (described in respective 'clauses').
+
+### `WITH` section
+
+#### `.with<NS extends ZodTypeAny>(schema: NS)`
+Defines the Zod schema that should be used to validate the query result.
+
+#### `.withSchema<T extends ZodRawShape>(schema: T)`
+Defines the schema that should be used to validate the query result, useful in situations where you need to validate the query result against the schema without creating one beforehand.
+
+This is short for `with(z.object(schema))`.
+
+#### `.withAny()`
+Defines a schema which accepts any value, useful in situations where a specific schema isn't needed.
+
+This is short for `with(z.any())`.
+
+### `WHERE` clause
+
+#### `.where(where: string | Where)`
+Defines a predicate function that determines whether a specific query will be deleted or not. All values will be escaped automatically. Use of `raw` is supported, as well as any operators wrapping the raw function.
+
+### `RETURN` clause
+
+#### `.return(mode: 'none' | 'before' | 'after' | 'diff')`
+Defines the return behavior mode `mode` for the query.
+
+Mode can be either one of these:
+- `'none'` - Doesn't return any result;
+- `'diff'` - Returns the changeset diff;
+- `'before'` - Returns the record before changes were applied;
+- `'after'` - Returns the record after changes were applied.
+
+If no value is set throughout query writer configuring, the default one is `'after'`.
+
+#### `.return(...fields: SchemaFields[])`
+Defines the return behavior mode for the query as returning specified fields.
+
+### `TIMEOUT` clause
+
+#### `.timeout(timeout: number)`
+Sets the timeout in seconds for the query.
+
+### `PARALLEL` clause
+
+#### `.parallel()`
+Runs the query in parallel.
+

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,11 +6,22 @@ sidebar_position: 5
 
 Cirql offers a flexible API for querying SurrealDB. This API is split into two parts: the Cirql class and the QueryWriter class.
 
-## `Cirql`
-The Cirql class (and `StatelessCirql` variant) is the main entry point for querying SurrealDB. It provides a simple API for sending queries to the database and receiving the results.
+## `Cirql` class
+The `Cirql` class (and its `Legacy` variants) is the main entry point for querying SurrealDB. It provides a simple API for sending queries to the database and receiving the results.
 
 ### `new Cirql(options: CirqlOptions)`
-Used to create a new Cirql instance. The `options` parameter is an object containing the following properties:
+Used to create a new Cirql instance. The `options` parameter is an object that may contain the following properties depending on what class is instantiated:
+
+|                | `Cirql`            | `LegacyCirqlStateful` | `LegacyCirqlStateless` |
+| -------------- | :----------------: | :------------------:  | :--------------------: |
+| `connection`   | :x:                | :heavy_check_mark:    | :heavy_check_mark:     |
+| `credentials`  | :x:                | :heavy_check_mark:    | :heavy_check_mark:     |
+| `logging`      | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark:     |
+| `logPrinter`   | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark:     |
+| `autoConnect`  | :x:                | :heavy_check_mark:    | :x:                    |
+| `retryCount`   | :x:                | :heavy_check_mark:    | :x:                    |
+| `retryDelay`   | :x:                | :heavy_check_mark:    | :x:                    |
+| `queryTimeout` | :x:                | :heavy_check_mark:    | :x:                    |
 
 #### `connection`
 An object containing the connection details for the database. The following properties are available:
@@ -36,7 +47,7 @@ logging output using `logPrinter`.
 A function that is called when a query is executed. The function receives the query string and the parameters as arguments. You can use this hook to log queries to a custom logging service.
 
 #### `autoConnect` (`true`)
-When enabled, the connection will be established automatically when the Cirql instance is created. When disabled, you will need to call `.connect()` manually.
+When enabled, the connection will be established automatically when the Cirql instance is created. When disabled, you will need to call `cirql.connect` manually.
 
 #### `retryCount` (`10`)
 The number of times to retry a query when it fails. This is useful when the connection is lost and the query needs to be retried.
@@ -44,30 +55,77 @@ The number of times to retry a query when it fails. This is useful when the conn
 #### `retryDelay` (`2000`)
 The delay in milliseconds between each retry.
 
-### `cirql.connect()`
+#### `queryTimeout` (`5000`)
+The maximum possible duration in milliseconds for query attempt to wait for server response. If no response after the timeout will be present, that attempt will be considered as failed.
+
+### `new Cirql(surreal: Surreal, options: CirqlOptions)`
+Although Cirql provides an API to configure SurrealDB connection, you can also pass an instance of `Surreal` connection class as the first parameter to the constructor. In that case `options` parameter can be placed second.
+
+That can be useful if you already have a preconfigured connection and just wait to add Cirql functionality on it.
+
+> Note: only works for `Cirql` class constructor.
+
+### Fields and methods
+The following table shows which fields and methods are available for each class:
+
+|                | `Cirql`            | `LegacyCirqlStateful` | `LegacyCirqlStateless` |
+| -------------- | :----------------: | :------------------:  | :--------------------: |
+| `connect`      | :x:                | :heavy_check_mark:    | :x:                    |
+| `disconnect`   | :x:                | :heavy_check_mark:    | :x:                    |
+| `isConnected`  | :x:                | :heavy_check_mark:    | :x:                    |
+| `ready`        | :x:                | :heavy_check_mark:    | :x:                    |
+| `handle`       | :heavy_check_mark: | :heavy_check_mark:    | :x:                    |
+| `query`        | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark:     |
+| `execute`      | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark:     |
+| `batch`        | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark:     |
+| `transaction`  | :heavy_check_mark: | :heavy_check_mark:    | :heavy_check_mark:     |
+
+#### `cirql.connect()`
 Establishes a connection to the database. This is only required when `autoConnect` is set to `false`.
 
-### `cirql.disconnect()`
+#### `cirql.disconnect()`
 Closes the connection to the database.
 
-### `cirql.isConnected`
+#### `cirql.isConnected`
 A boolean indicating whether the connection is currently open.
 
-### `cirql.ready()`
+#### `cirql.ready()`
 Returns a promise which can be awaited for the connection to open. This is useful if you need to execute queries as soon as the connection is available.
 
-### `cirql.execute(query: QueryRequest)`
+#### `cirql.handle`
+Returns an underlying `Surreal` instance. All of its methods can be found [here](https://docs.surrealdb.com/docs/integration/sdks/nodejs).
+
+#### `cirql.query(query: string, params: Record<string, any>)`
+Sends a raw SQL query to the database with provided parameters (`params`) as an object and returns the result bypassing the validation logic. Here is an example of such operation:
+
+```ts
+const result = await cirql.query("SELECT * FROM user WHERE email = $email", {
+    email: "john@doe.org",
+});
+```
+
+However, as validation is bypassed, the type of `result` is `any`.
+
+#### `cirql.execute(query: QueryRequest)`
 Sends a single query to the database and returns the results. The `query` parameter is an object containing the following properties:
 
-#### `query`
-The query to execute, passed as an instance of `QueryWriter`. If you need to execute a raw query string, you can use the `query()` function to wrap a raw string in a `QueryWriter` instance.
+##### `query`
+The query to execute, passed as an instance of `QueryWriter`. If you need to execute a raw query string, you can use the `query()` function to wrap a raw string in a `QueryWriter` instance or use the `cirql.query` method mentioned above.
 
-#### `schema`
-The Zod schema to use for the query. Query results are automatically validated against this schema. If the results don't match the schema, an error will be thrown.
+##### `schema`
+The Zod schema to use for the query. Query results are automatically validated against this schema unless `validate` is set to `false`. If the results don't match the schema, an error will be thrown.
 
 Besides aiding in validation the schema also provides TypeScript typings for the results. This allows you to use the results in your code without having to cast them to a specific type.
 
-### `cirql.batch(...queries: QueryRequest[])`
+> Note: you can provide validation schema via `.with` or `.with`-like methods in query writer itself. In that case you do not have to specify this exact property.
+
+##### `params` (`{}`)
+The object containing parameters for the query. They function the same as in the `cirql.query` method.
+
+##### `validate` (`true`)
+Determines whether to validate query result against the provided schema or not.
+
+#### `cirql.batch(...queries: QueryRequest[])`
 Allows you to send multiple queries in a single request. Returns an array containing the results of each query in the same order as the queries were passed to the function. This allows you to destructure the results easily, for example:
 
 ```ts
@@ -77,5 +135,5 @@ const [users, organisations] = await cirql.batch(
 );
 ```
 
-### `cirql.transaction(...queries: QueryRequest[])`
-Similar to `batch`, except that all queries are executed in a single transaction. This means that either all queries will succeed or none of them will. This is useful for situations where you need to ensure that all queries succeed or fail together.
+#### `cirql.transaction(...queries: QueryRequest[])`
+Similar to `cirql.batch`, except that all queries are executed in a single transaction. This means that either all queries will succeed or none of them will. This is useful for situations where you need to ensure that all queries succeed or fail together.

--- a/docs/api/let.md
+++ b/docs/api/let.md
@@ -3,3 +3,71 @@ sidebar_position: 7
 ---
 
 # Let parameters
+Let query writer is used for creating intermediate variables in query that, for exapmple, would be too complex or repeating otherwise.
+
+This statement is particularly useful in combination with multi-statement executors - `batch` and `transaction`.
+
+## `letValue(name: string, value: any)`
+Used to create let query writer with provided name and value.
+
+#### `name`
+Name should be a string containing only alphanumeric characters.
+
+#### `value`
+Value of variable could be anything. The final value that would be inserted into query is depending on the type on `value` as such:
+- if a raw query - the raw value;
+- if a query writer - the final query execution result;
+- if null - the string `'NONE'`;
+- if date - the ISO formatted string;
+- otherwise - the JSON value stringified.
+
+## Reserved names
+You can not define variables with reserved names, but can access them in queries:
+
+| Variable name | Value      |
+|-------------- | ---------- |
+| `$auth`	    | Represents the currently authenticated scope user |
+| `$token`	    | Represents values held inside the JWT token used for the current session |
+| `$Scope`	    | Represents the name of the scope of a currently authenticated scope user |
+| `$session`	| Represents values from the session functions as an object |
+| `$before`	    | Represents the value before a mutation on a field |
+| `$after`	    | Represents the value after a mutation on a field |
+| `$value`	    | Represents the value after a mutation on a field (identical to `$after` in the case of an event) |
+| `$input`	    | Represents the initially inputted value in a field definition, as the value clause could have modified the `$value` variable |
+| `$parent`	    | Represents the parent record in a subquery |
+| `$event`	    | Represents the type of table event triggered on an event |
+
+## Helper functions
+
+### `param(value: string)`
+Used to insert variable name into query, which would otherwise require the `'$'` symbol to prefix the name.
+
+So, `param('people')` and `'$people'` are basically the same.
+
+## Examples
+Those are 2 examples how let parameters can be used to factor up the logic of the query.
+
+1. Using `letValue` for query writer:
+```ts
+await cirql.transaction({
+	query: letValue('orgs', select('name').from('organisation'))
+}, {
+	query: select()
+		.from('$orgs') // Note the '$' marking a variable
+		.withAny()
+})
+```
+
+2. Using `letValue` for raw value:
+```ts
+await ciqrl.transaction({
+	query: letValue('people', ['Alfred', 'Bob', 'John'])
+}, {
+	query: select()
+		.from('person')
+		.with(RecordSchema)
+		.where({
+			name: inside(param('people'))
+		})
+})
+```

--- a/docs/api/relate.md
+++ b/docs/api/relate.md
@@ -3,3 +3,92 @@ sidebar_position: 6
 ---
 
 # Relate
+Create query writer resembles `RELATE` SQL statement. It is used to relate various entities in SurrealDB database between themselves in logical 2-way verb (its object and subject) relationship.
+
+For additional information about that statement in SurrealQL you can refer to [official docs](https://docs.surrealdb.com/docs/surrealql/statements/relate/).
+
+## `relate(from: SurrealValue, edge: string, to: SurrealValue)`
+Starts a new relate query writer for a relation described as a set of parameters.
+
+## `relateRelation(relation: RecordRelation)`
+Starts a new relate query writer for a relation described as `RecordRelation` object.
+
+This function is especially useful in situations where the table name within a record pointer may be spoofed, and a specific table name is required.
+
+> Note: these two expressions will build up the same writer: 
+>
+> ```ts
+> relate(
+>     'person:l19zjikkw1p1h9o6ixrg', 
+>     'wrote', 
+>     'article:8nkk6uj4yprt49z7y3zm'
+> )
+> ```
+> and:
+> ```ts
+> relateRelation({
+>     fromId: 'person:l19zjikkw1p1h9o6ixrg',
+>     edge: 'wrote',
+>     toId: 'article:8nkk6uj4yprt49z7y3zm'
+> })
+> ```
+
+## Methods
+Cirql provides methods of 2 types:
+- Cirql-native above SurrealQL (described in 'sections');
+- SurrealQL-native resembling SurrealQL clauses (described in respective 'clauses').
+
+### `WITH` section
+
+#### `.with<NS extends ZodTypeAny>(schema: NS)`
+Defines the Zod schema that should be used to validate the query result.
+
+#### `.withSchema<T extends ZodRawShape>(schema: T)`
+Defines the schema that should be used to validate the query result, useful in situations where you need to validate the query result against the schema without creating one beforehand.
+
+This is short for `with(z.object(schema))`.
+
+#### `.withAny()`
+Defines a schema which accepts any value, useful in situations where a specific schema isn't needed.
+
+This is short for `with(z.any())`.
+
+### `SET/CONTENT` clause
+
+#### `.set(key: SchemaFields, value: any)`
+Sets an individual field to a value.
+
+#### `.setAll(fields: SchemaInput)`
+Sets multiple fields at once using an object. Supports recursive objects and raw values. Can be used as effective alternative to `content`.
+
+#### `.content(content: SchemaInput)`
+Sets the content for the created record.
+
+The content is serialized to JSON, meaning you can not use raw query values. Thus, when raw values are needed, use the `setAll` function instead.
+
+### `RETURN` clause
+
+#### `.return(mode: 'none' | 'before' | 'after' | 'diff')`
+Defines the return behavior mode `mode` for the query.
+
+Mode can be either one of these:
+- `'none'` - Doesn't return any result;
+- `'diff'` - Returns the changeset diff;
+- `'before'` - Returns the record before changes were applied;
+- `'after'` - Returns the record after changes were applied.
+
+If no value is set throughout query writer configuring, the default one is `'after'`.
+
+#### `.return(...fields: SchemaFields[])`
+Defines the return behavior mode for the query as returning specified fields.
+
+### `TIMEOUT` clause
+
+#### `.timeout(timeout: number)`
+Sets the timeout in seconds for the query.
+
+### `PARALLEL` clause
+
+#### `.parallel()`
+Runs the query in parallel.
+

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -3,3 +3,125 @@ sidebar_position: 1
 ---
 
 # Select
+
+Select query writer resembles `SELECT` SQL statement. It is used to recieve information from SurrealDB database.
+
+For additional information about that statement in SurrealQL you can refer to [official docs](https://docs.surrealdb.com/docs/surrealql/statements/select/).
+
+## `select(...projections: string[])`
+Starts a new select query writer with given projections to return. Omitting that parameter will select all projections.
+
+> Note: `select('*')` works the same way as `select()`.
+
+## `selectValue(projection: string)`
+Starts a new select query writer with only one given projection to return.
+
+The difference is that, for example, `select('id')` would return a set of *records* with one projection 'id' while `selectValue('id')` would return a set of respective *IDs themselves* without being wrapped in record.
+
+## Methods
+Cirql provides methods of 2 types:
+- Cirql-native above SurrealQL (described in 'sections');
+- SurrealQL-native resembling SurrealQL clauses (described in respective 'clauses').
+
+### `WITH` section
+
+#### `.with<NS extends ZodTypeAny>(schema: NS)`
+Defines the Zod schema that should be used to validate the query result.
+
+#### `.withSchema<T extends ZodRawShape>(schema: T)`
+Defines the schema that should be used to validate the query result, useful in situations where you need to validate the query result against the schema without creating one beforehand.
+
+This is short for `with(z.object(schema))`.
+
+#### `.withAny()`
+Defines a schema which accepts any value, useful in situations where a specific schema isn't needed. 
+
+This is short for `with(z.any())`.
+
+### `AND` section
+
+#### `.and(projection: string)`
+Appends another projection to the query.
+
+> Note: usually it is recommended to pass projections to `select`, however in certain situations it may be useful to add additional ones to the query.
+
+#### `.andQuery(alias: string, query: SelectQueryWriter)`
+Appends a subquery projection to the query. The query will be aliased with the given alias.
+
+#### `.andQueryOne(alias: string, query: SelectQueryWriter)`
+Appends a subquery projection to the query. The query will be aliased with the given alias. Unlike `andQuery`, this will only take *the first* record from the subquery.
+
+### `FROM` clause
+
+#### `.from(...targets: Surreal[])`
+Specifies the targets for the query. This can include table names, record IDs, and subqueries.
+
+#### `.fromRecord(record: string)`
+Specifies the target for the query as a record pointer.
+
+> Note: this function automatically sets the limit to 1.
+
+#### `.fromRecord(table: string, id: string)`
+Specifies the target for the query as a record pointer. This function is especially useful in situations where the table name within a record pointer may be spoofed, and a specific table name is required.
+
+> Note: this function automatically sets the limit to 1.
+
+#### `.fromRelation(relation: RecordRelation)`
+Specifies the target for the query as a relation. This function is especially useful in situations where the table names within a record pointer may be spoofed, and specific table names are required.
+
+Since this function will automatically configures a `WHERE` clause, calling `.where()` manually will throw an exception.
+
+### `WHERE` clause
+
+#### `.where(where: string | Where)`
+Defines a predicate function that determines whether a specific query will be included in the final result or not. All values will be escaped automatically. Use of `raw` is supported, as well as any operators wrapping the raw function.
+
+### `SPLIT` clause
+
+#### `.split(...split: SchemaFields[])`
+Defines the split fields for the query.
+
+### `GROUP BY/GROUP ALL` clause
+
+#### `.groupBy(...group: SchemaFields[])`
+Defines the fields to group by. If you are grouping by all fields, use the `groupAll()` method instead.
+
+#### `.groupAll()`
+Groups by all fields.
+
+### `ORDER BY` clause
+
+#### `.orderBy(ordering: { [fieldName]: 'asc' | 'desc' })`
+Defines the order of query results for each of specified fields.
+
+#### `.orderBy(field: SchemaFields, order: 'asc' | 'desc')`
+Defines the order of the query results, sorting only for specified fields. If no order is specified, the default order is ascending.
+
+### `LIMIT` and `START` clause
+
+#### `.limit(limit: number)`
+Limits the number of records returned by the query.
+
+#### `.one()`
+Limits the number of records returned by the query to one. This is useful for queries that are expected to return a single record.
+
+Unlike `limit(1)`, this method will cause the query to return not an *array of records* when executed, but a *single record* instead.
+
+#### `.start(start: number)`
+Starts the query at the given index.
+
+### `FETCH` clause
+
+#### `.fetch(...fetch: SchemaFields[])`
+Defines the paths to the fields to fetch.
+
+### `TIMEOUT` clause
+
+#### `.timeout(timeout: number)`
+Sets the timeout in seconds for the query.
+
+### `PARALLEL` clause
+
+#### `.parallel()`
+Runs the query in parallel.
+

--- a/docs/api/update.md
+++ b/docs/api/update.md
@@ -3,3 +3,97 @@ sidebar_position: 3
 ---
 
 # Update
+Update query writer resembles `UPDATE` SQL statement. It is used to update/change various entities in SurrealDB database.
+
+For additional information about that statement in SurrealQL you can refer to [official docs](https://docs.surrealdb.com/docs/surrealql/statements/update/).
+
+## `update(...targets: SurrealValue[])`
+Starts a new update query writer with the given targets.
+
+## `updateRecord(record: string)`
+Starts a new update query writer for the given record.
+
+Unlike the `update` function this function will ensure that the record is a valid record link, which may be beneficial in situations where potential injection attacks are a concern.
+
+## `updateRecord(table: string, id: string)`
+Starts a new update query writer for the given record. This function is especially useful in situations where the table name within a record pointer may be spoofed, and a specific table name is required.
+
+## `updateRelation(relation: RecordRelation)`
+Starts a new update query writer for the given relation. This function is especially useful in situations where the table names within a record pointer may be spoofed, and specific table names are required.
+
+Since this function will automatically configure a `WHERE` clause, calling `.where()` manually will throw an exception.
+
+## Methods
+Cirql provides methods of 2 types:
+- Cirql-native above SurrealQL (described in 'sections');
+- SurrealQL-native resembling SurrealQL clauses (described in respective 'clauses').
+
+### `WITH` section
+
+#### `.with<NS extends ZodTypeAny>(schema: NS)`
+Defines the Zod schema that should be used to validate the query result.
+
+#### `.withSchema<T extends ZodRawShape>(schema: T)`
+Defines the schema that should be used to validate the query result, useful in situations where you need to validate the query result against the schema without creating one beforehand.
+
+This is short for `with(z.object(schema))`.
+
+#### `.withAny()`
+Defines a schema which accepts any value, useful in situations where a specific schema isn't needed.
+
+This is short for `with(z.any())`.
+
+### `SET/CONTENT/MERGE/PATCH` clause
+
+#### `.set(key: SchemaFields, value: any)`
+Sets an individual field to a value.
+
+#### `.setAll(fields: SchemaInput)`
+Sets multiple fields at once using an object. Supports recursive objects and raw values. Can be used as effective alternative to `content`.
+
+#### `.content(content: SchemaInput)`
+Sets the content for the created record.
+
+The content is serialized to JSON, meaning you can not use raw query values. Thus, when raw values are needed, use the `setAll` function instead.
+
+#### `.merge(content: SchemaInput)`
+Merges the content into the record, specifying only fields that would be changed.
+
+The content is serialized to JSON, meaning you can not use raw query values. Thus, when raw values are needed, use the `setAll` function instead.
+
+#### `.patch(content: SchemaInput)`
+Applies the given list of patches to the record. Those patches work similar to [JSON patch specification](https://jsonpatch.com/).
+
+The content is serialized to JSON, meaning you can not use raw query values. Thus, when raw values are needed, use the `setAll` function instead.
+
+### `WHERE` clause
+
+#### `.where(where: string | Where)`
+Defines a predicate function that determines whether a specific query will be updated or not. All values will be escaped automatically. Use of `raw` is supported, as well as any operators wrapping the raw function.
+
+### `RETURN` clause
+
+#### `.return(mode: 'none' | 'before' | 'after' | 'diff')`
+Defines the return behavior mode `mode` for the query.
+
+Mode can be either one of these:
+- `'none'` - Doesn't return any result;
+- `'diff'` - Returns the changeset diff;
+- `'before'` - Returns the record before changes were applied;
+- `'after'` - Returns the record after changes were applied.
+
+If no value is set throughout query writer configuring, the default one is `'after'`.
+
+#### `.return(...fields: SchemaFields[])`
+Defines the return behavior mode for the query as returning specified fields.
+
+### `TIMEOUT` clause
+
+#### `.timeout(timeout: number)`
+Sets the timeout in seconds for the query.
+
+### `PARALLEL` clause
+
+#### `.parallel()`
+Runs the query in parallel.
+


### PR DESCRIPTION
After updating Guide, I guess the logical continuation would be filling up the API reference. I tried to make docs align with explainers in Ciqrl source code as they are helpfully structured, but that resulted in many "Ctrl-C Ctrl-V"s between pages.

I think that also references https://github.com/StarlaneStudios/cirql/issues/4 (it is closed, but however).